### PR TITLE
Add files via upload

### DIFF
--- a/PF_B1 (1).idf
+++ b/PF_B1 (1).idf
@@ -1,0 +1,2366 @@
+!-Generator IDFEditor 1.51
+!-Option SortedOrder
+
+!-NOTE: All comments with '!-' are ignored by the IDFEditor and are generated automatically.
+!-      Use '!' comments if they need to be retained when using the IDFEditor.
+
+
+!-   ===========  ALL OBJECTS IN CLASS: VERSION ===========
+
+Version,
+    9.5;                     !- Version Identifier
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SIMULATIONCONTROL ===========
+
+SimulationControl,
+    No,                      !- Do Zone Sizing Calculation
+    No,                      !- Do System Sizing Calculation
+    No,                      !- Do Plant Sizing Calculation
+    No,                      !- Run Simulation for Sizing Periods
+    Yes,                     !- Run Simulation for Weather File Run Periods
+    No,                      !- Do HVAC Sizing Simulation for Sizing Periods
+    1;                       !- Maximum Number of HVAC Sizing Simulation Passes
+
+
+!-   ===========  ALL OBJECTS IN CLASS: BUILDING ===========
+
+Building,
+    Building 1,              !- Name
+    ,                        !- North Axis {deg}
+    ,                        !- Terrain
+    ,                        !- Loads Convergence Tolerance Value {W}
+    ,                        !- Temperature Convergence Tolerance Value {deltaC}
+    ,                        !- Solar Distribution
+    ,                        !- Maximum Number of Warmup Days
+    ;                        !- Minimum Number of Warmup Days
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SHADOWCALCULATION ===========
+
+ShadowCalculation,
+    PolygonClipping,         !- Shading Calculation Method
+    Periodic,                !- Shading Calculation Update Frequency Method
+    20,                      !- Shading Calculation Update Frequency
+    15000,                   !- Maximum Figures in Shadow Overlap Calculations
+    SutherlandHodgman;       !- Polygon Clipping Algorithm
+
+
+!-   ===========  ALL OBJECTS IN CLASS: HEATBALANCEALGORITHM ===========
+
+HeatBalanceAlgorithm,
+    ConductionTransferFunction,  !- Algorithm
+    200;                     !- Surface Temperature Upper Limit {C}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: TIMESTEP ===========
+
+Timestep,
+    6;                       !- Number of Timesteps per Hour
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SITE:LOCATION ===========
+
+Site:Location,
+    Temixco,                 !- Name
+    18.85,                   !- Latitude {deg}
+    -99.14,                  !- Longitude {deg}
+    -6,                      !- Time Zone {hr}
+    1280;                    !- Elevation {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: RUNPERIOD ===========
+
+RunPeriod,
+    Run Period 1,            !- Name
+    5,                       !- Begin Month
+    3,                       !- Begin Day of Month
+    2019,                    !- Begin Year
+    6,                       !- End Month
+    24,                      !- End Day of Month
+    2019,                    !- End Year
+    Friday,                  !- Day of Week for Start Day
+    No,                      !- Use Weather File Holidays and Special Days
+    No,                      !- Use Weather File Daylight Saving Period
+    No,                      !- Apply Weekend Holiday Rule
+    Yes,                     !- Use Weather File Rain Indicators
+    Yes;                     !- Use Weather File Snow Indicators
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SITE:GROUNDTEMPERATURE:BUILDINGSURFACE ===========
+
+Site:GroundTemperature:BuildingSurface,
+    21,                      !- January Ground Temperature {C}
+    21,                      !- February Ground Temperature {C}
+    21,                      !- March Ground Temperature {C}
+    21,                      !- April Ground Temperature {C}
+    21,                      !- May Ground Temperature {C}
+    21,                      !- June Ground Temperature {C}
+    21,                      !- July Ground Temperature {C}
+    21,                      !- August Ground Temperature {C}
+    21,                      !- September Ground Temperature {C}
+    21,                      !- October Ground Temperature {C}
+    21,                      !- November Ground Temperature {C}
+    21;                      !- December Ground Temperature {C}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SCHEDULETYPELIMITS ===========
+
+ScheduleTypeLimits,
+    Mac,                     !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    HP,                      !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    MonitorDell,             !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Fuente,                  !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Agilent,                 !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Regulador,               !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Telefono,                !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SCHEDULE:COMPACT ===========
+
+Schedule:Compact,
+    Mac,                     !- Name
+    Mac,                     !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    HP,                      !- Name
+    HP,                      !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     .4,                     !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    MonitorDell,             !- Name
+    MonitorDell,             !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00 ,           !- Field 5
+     1,                      !- Field 6
+    Until: 24:00 ,           !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Fuente,                  !- Name
+    Fuente,                  !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until:24:00,             !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until:24:00,             !- Field 10
+     .2,                     !- Field 11
+    For:AllOtherDays,        !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Agilent,                 !- Name
+    Agilent,                 !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends:,          !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Regulador,               !- Name
+    Regulador,               !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Telefono,                !- Name
+    Telefono,                !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+
+!-   ===========  ALL OBJECTS IN CLASS: MATERIAL ===========
+
+Material,
+    CAD,                     !- Name
+    Rough,                   !- Roughness
+    0.1,                     !- Thickness {m}
+    2,                       !- Conductivity {W/m-K}
+    2400,                    !- Density {kg/m3}
+    10000,                   !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.6,                     !- Solar Absorptance
+    0.6;                     !- Visible Absorptance
+
+Material,
+    MorteroAltaDensidad,     !- Name
+    Rough,                   !- Roughness
+    0.1,                     !- Thickness {m}
+    0.88,                    !- Conductivity {W/m-K}
+    2800,                    !- Density {kg/m3}
+    896,                     !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.2,                     !- Solar Absorptance
+    0.2;                     !- Visible Absorptance
+
+Material,
+    Tabique,                 !- Name
+    MediumRough,             !- Roughness
+    0.14,                    !- Thickness {m}
+    0.7,                     !- Conductivity {W/m-K}
+    1970,                    !- Density {kg/m3}
+    800,                     !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.65,                    !- Solar Absorptance
+    0.65;                    !- Visible Absorptance
+
+
+!-   ===========  ALL OBJECTS IN CLASS: WINDOWMATERIAL:GLAZING ===========
+
+WindowMaterial:Glazing,
+    Clear 3mm,               !- Name
+    SpectralAverage,         !- Optical Data Type
+    ,                        !- Window Glass Spectral Data Set Name
+    0.00299999999999999,     !- Thickness {m}
+    0.837,                   !- Solar Transmittance at Normal Incidence
+    0.075,                   !- Front Side Solar Reflectance at Normal Incidence
+    0,                       !- Back Side Solar Reflectance at Normal Incidence
+    0.898,                   !- Visible Transmittance at Normal Incidence
+    0.081,                   !- Front Side Visible Reflectance at Normal Incidence
+    0,                       !- Back Side Visible Reflectance at Normal Incidence
+    0,                       !- Infrared Transmittance at Normal Incidence
+    0.84,                    !- Front Side Infrared Hemispherical Emissivity
+    0.84,                    !- Back Side Infrared Hemispherical Emissivity
+    0.9,                     !- Conductivity {W/m-K}
+    1,                       !- Dirt Correction Factor for Solar and Visible Transmittance
+    No;                      !- Solar Diffusing
+
+
+!-   ===========  ALL OBJECTS IN CLASS: CONSTRUCTION ===========
+
+Construction,
+    CAD,                     !- Name
+    CAD;                     !- Outside Layer
+
+Construction,
+    MorteroAltaDensidad,     !- Name
+    MorteroAltaDensidad;     !- Outside Layer
+
+Construction,
+    Tabique,                 !- Name
+    Tabique;                 !- Outside Layer
+
+Construction,
+    VidrioClaro3mm,          !- Name
+    Clear 3mm;               !- Outside Layer
+
+
+!-   ===========  ALL OBJECTS IN CLASS: GLOBALGEOMETRYRULES ===========
+
+GlobalGeometryRules,
+    UpperLeftCorner,         !- Starting Vertex Position
+    Counterclockwise,        !- Vertex Entry Direction
+    Relative,                !- Coordinate System
+    Relative,                !- Daylighting Reference Point Coordinate System
+    Relative;                !- Rectangular Surface Coordinate System
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ZONE ===========
+
+Zone,
+    Cubiculo,                !- Name
+    ,                        !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    CubiculoTecho,           !- Name
+    -0,                      !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    6.13906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+Zone,
+    Thermal Zone 1,          !- Name
+    ,                        !- Direction of Relative North {deg}
+    13.6484710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    Thermal Zone 4,          !- Name
+    ,                        !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    Thermal Zone 5,          !- Name
+    -0,                      !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+Zone,
+    Thermal Zone 6,          !- Name
+    -0,                      !- Direction of Relative North {deg}
+    11.0084710655839,        !- X Origin {m}
+    6.13906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ZONELIST ===========
+
+ZoneList,
+    189.1-2009 - Office - OpenOffice - CZ4-8,  !- Name
+    Cubiculo,                !- Zone 1 Name
+    CubiculoTecho,           !- Zone 2 Name
+    Thermal Zone 1,          !- Zone 3 Name
+    Thermal Zone 4,          !- Zone 4 Name
+    Thermal Zone 5,          !- Zone 5 Name
+    Thermal Zone 6;          !- Zone 6 Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: BUILDINGSURFACE:DETAILED ===========
+
+BuildingSurface:Detailed,
+    Surface 1,               !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Cubiculo,                !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 2,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 17,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 3,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 4,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 5,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 6,               !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Cubiculo,                !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 38,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 10,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 1 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 2 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773899;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 11,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 23,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0.691254272191099,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773899;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 12,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 3 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0.643980043849753,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735478;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 37,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.691254272191099,       !- Vertex 1 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    1.42622480146457e-014,   !- Vertex 2 Y-coordinate {m}
+    -2.50674674139746e-015,  !- Vertex 2 Z-coordinate {m}
+    -8.46944029798595e-031,  !- Vertex 3 X-coordinate {m}
+    1.71704131784969e-016,   !- Vertex 3 Y-coordinate {m}
+    -2.51983539825036e-015,  !- Vertex 3 Z-coordinate {m}
+    8.50457922036746e-031,   !- Vertex 4 X-coordinate {m}
+    0.691254272191099,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796446;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 38,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 6,               !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.25140085038001e-030,  !- Vertex 1 X-coordinate {m}
+    2.77288417974636e-016,   !- Vertex 1 Y-coordinate {m}
+    -1.73767408597438e-015,  !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    1.41820036321952e-014,   !- Vertex 2 Y-coordinate {m}
+    -3.44770478377269e-015,  !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 3 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 3 Z-coordinate {m}
+    2.15978859856317e-030,   !- Vertex 4 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934963;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 7,               !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 1 Y-coordinate {m}
+    -0.600382699934965,      !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 2 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934965;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 8,               !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0.691254272191099,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0.691254272191099,       !- Vertex 3 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0.643980043849753,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735478;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 9,               !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0.691254272191099,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796445;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 25,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 26,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 27,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 28,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 29,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 15,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 30,              !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 41,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 13,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 14,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 15,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 29,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 16,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 17,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 2,               !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 18,              !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 39,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 19,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    4.78869153650636e-033,   !- Vertex 1 X-coordinate {m}
+    -0.00239825292575829,    !- Vertex 1 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -0.00239825292575862,    !- Vertex 4 Y-coordinate {m}
+    -0.600382699934967;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 20,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 1 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.6334746597739;        !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 21,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 33,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    4.4512542721911,         !- Vertex 2 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.6334746597739;        !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 22,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    4.4512542721911,         !- Vertex 2 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    4.4512542721911,         !- Vertex 3 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    4.40398004384975,        !- Vertex 4 Y-coordinate {m}
+    0.406558363735487;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 23,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 11,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    4.4512542721911,         !- Vertex 4 Y-coordinate {m}
+    0.110306532796444;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 24,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 3 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    4.40398004384975,        !- Vertex 4 Y-coordinate {m}
+    0.406558363735487;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 39,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 18,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76000000000001,        !- Vertex 1 Y-coordinate {m}
+    -5.49893739466798e-015,  !- Vertex 1 Z-coordinate {m}
+    1.46653678305508e-032,   !- Vertex 2 X-coordinate {m}
+    3.76000000000001,        !- Vertex 2 Y-coordinate {m}
+    -5.68617986466966e-015,  !- Vertex 2 Z-coordinate {m}
+    -1.83366980085391e-032,  !- Vertex 3 X-coordinate {m}
+    -0.00239825292575823,    !- Vertex 3 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -0.00239825292575865,    !- Vertex 4 Y-coordinate {m}
+    -0.600382699934967;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 40,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.4512542721911,         !- Vertex 1 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76000000000001,        !- Vertex 2 Y-coordinate {m}
+    -5.05337993672583e-015,  !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76000000000001,        !- Vertex 3 Y-coordinate {m}
+    -5.05337993672583e-015,  !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    4.4512542721911,         !- Vertex 4 Y-coordinate {m}
+    0.110306532796444;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 31,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 1 Y-coordinate {m}
+    -0.600382699934981,      !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934981;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 32,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    0.691254272191086,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0.691254272191086,       !- Vertex 3 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0.643980043849737,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735468;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 33,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 21,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    0.691254272191086,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796432;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 34,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 1 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773917;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 35,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0.691254272191086,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773917;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 36,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 3 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    0.643980043849737,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735468;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 41,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 30,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -3.61448906568977e-030,  !- Vertex 1 X-coordinate {m}
+    3.51987407594703e-016,   !- Vertex 1 Y-coordinate {m}
+    -2.20578775426009e-015,  !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -3.54287221259964e-016,  !- Vertex 2 Y-coordinate {m}
+    -6.44273711449143e-015,  !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 3 Y-coordinate {m}
+    -0.600382699934983,      !- Vertex 3 Z-coordinate {m}
+    3.57836420912889e-030,   !- Vertex 4 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934979;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 42,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.691254272191086,       !- Vertex 1 Y-coordinate {m}
+    0.11030653279643,        !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -1.31014272181014e-017,  !- Vertex 2 Y-coordinate {m}
+    -6.41510049855691e-015,  !- Vertex 2 Z-coordinate {m}
+    -1.38651208186076e-031,  !- Vertex 3 X-coordinate {m}
+    1.40511909077371e-017,   !- Vertex 3 Y-coordinate {m}
+    -2.25378838828529e-015,  !- Vertex 3 Z-coordinate {m}
+    1.48976334907254e-031,   !- Vertex 4 X-coordinate {m}
+    0.691254272191086,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796434;       !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: FENESTRATIONSURFACE:DETAILED ===========
+
+FenestrationSurface:Detailed,
+    VCNI,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 3,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.34,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    2.34,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCNS,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 3,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.34,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    2.34,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    PuertaJorge,             !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.0500000000000002,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.05,                    !- Vertex 2 Z-coordinate {m}
+    0.950000000000001,       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 Z-coordinate {m}
+    0.950000000000001,       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCSI,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.98,                    !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    0.98,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    2.32,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    2.32,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCSS,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.0500000000000002,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    2.32,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    2.32,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VNT,                     !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 37,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.79,                    !- Vertex 1 X-coordinate {m}
+    0.592503661878085,       !- Vertex 1 Y-coordinate {m}
+    0.0945484566826738,      !- Vertex 1 Z-coordinate {m}
+    2.79,                    !- Vertex 2 X-coordinate {m}
+    0.345627136095554,       !- Vertex 2 Y-coordinate {m}
+    0.0551532663982288,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    0.345627136095554,       !- Vertex 3 Y-coordinate {m}
+    0.0551532663982288,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    0.592503661878085,       !- Vertex 4 Y-coordinate {m}
+    0.0945484566826738;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VST,                     !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 7,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.79,                    !- Vertex 1 X-coordinate {m}
+    -5.33253295690264,       !- Vertex 1 Y-coordinate {m}
+    -0.850936110144037,      !- Vertex 1 Z-coordinate {m}
+    2.79,                    !- Vertex 2 X-coordinate {m}
+    -5.72753539815469,       !- Vertex 2 Y-coordinate {m}
+    -0.913968414599151,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599152,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    -5.33253295690264,       !- Vertex 4 Y-coordinate {m}
+    -0.850936110144037;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 7,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.05,                    !- Vertex 2 Z-coordinate {m}
+    -1.69,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.05,                    !- Vertex 3 Z-coordinate {m}
+    -1.69,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 8,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 9,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -1.66,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -1.66,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 14,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 28,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 15,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 28,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 4,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.950000000000001,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -0.950000000000001,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 5,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    -0.98,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.98,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 6,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 12,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 16,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 13,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 16,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 17,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 19,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0500000000000002,     !- Vertex 1 X-coordinate {m}
+    -1.57253295690265,       !- Vertex 1 Y-coordinate {m}
+    -0.850936110144044,      !- Vertex 1 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 2 X-coordinate {m}
+    -1.9675353981547,        !- Vertex 2 Y-coordinate {m}
+    -0.913968414599158,      !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    -1.9675353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599158,      !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    -1.57253295690265,       !- Vertex 4 Y-coordinate {m}
+    -0.850936110144044;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 20,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 40,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0500000000000002,     !- Vertex 1 X-coordinate {m}
+    4.35250366187809,        !- Vertex 1 Y-coordinate {m}
+    0.0945484566826661,      !- Vertex 1 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 2 X-coordinate {m}
+    4.10562713609556,        !- Vertex 2 Y-coordinate {m}
+    0.0551532663982204,      !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    4.10562713609556,        !- Vertex 3 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    4.35250366187809,        !- Vertex 4 Y-coordinate {m}
+    0.094548456682666;       !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 18,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 31,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.59,                    !- Vertex 1 X-coordinate {m}
+    -5.33253295690265,       !- Vertex 1 Y-coordinate {m}
+    -0.85093611014404,       !- Vertex 1 Z-coordinate {m}
+    2.59,                    !- Vertex 2 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 2 Y-coordinate {m}
+    -0.913968414599155,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599155,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    -5.33253295690265,       !- Vertex 4 Y-coordinate {m}
+    -0.85093611014404;       !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 21,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 42,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.59,                    !- Vertex 1 X-coordinate {m}
+    0.592503661878087,       !- Vertex 1 Y-coordinate {m}
+    0.0945484566826618,      !- Vertex 1 Z-coordinate {m}
+    2.59,                    !- Vertex 2 X-coordinate {m}
+    0.345627136095556,       !- Vertex 2 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    0.345627136095556,       !- Vertex 3 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    0.592503661878087,       !- Vertex 4 Y-coordinate {m}
+    0.0945484566826618;      !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SHADING:BUILDING:DETAILED ===========
+
+Shading:Building:Detailed,
+    Shading Surface 1,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    4.9284710655839,         !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    5.40379559078073,        !- Vertex 1 Z-coordinate {m}
+    4.9284710655839,         !- Vertex 2 X-coordinate {m}
+    0.8868915534472,         !- Vertex 2 Y-coordinate {m}
+    3.46095594197053,        !- Vertex 2 Z-coordinate {m}
+    18.1284710655839,        !- Vertex 3 X-coordinate {m}
+    0.8868915534472,         !- Vertex 3 Y-coordinate {m}
+    3.46095594197053,        !- Vertex 3 Z-coordinate {m}
+    18.1284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    5.40379559078073;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 4,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    21.9884710655839,        !- Vertex 1 X-coordinate {m}
+    3.61703301654305,        !- Vertex 1 Y-coordinate {m}
+    4.72,                    !- Vertex 1 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 2 X-coordinate {m}
+    3.61703301654305,        !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 3 X-coordinate {m}
+    -4.05296698345695,       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 4 X-coordinate {m}
+    -4.05296698345695,       !- Vertex 4 Y-coordinate {m}
+    4.72;                    !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 5,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    24.1261916075609,        !- Vertex 1 X-coordinate {m}
+    4.91323935984245,        !- Vertex 1 Y-coordinate {m}
+    4.72,                    !- Vertex 1 Z-coordinate {m}
+    24.1261916075609,        !- Vertex 2 X-coordinate {m}
+    4.91323935984245,        !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 3 X-coordinate {m}
+    3.61703301654305,        !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 4 X-coordinate {m}
+    3.61703301654305,        !- Vertex 4 Y-coordinate {m}
+    4.72;                    !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 6,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    18.6284710655839,        !- Vertex 1 X-coordinate {m}
+    2.37667133434807,        !- Vertex 1 Y-coordinate {m}
+    3.90341289084577,        !- Vertex 1 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 2 X-coordinate {m}
+    2.37667133434807,        !- Vertex 2 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 2 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 3 X-coordinate {m}
+    2.37667133434807,        !- Vertex 3 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 3 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 4 X-coordinate {m}
+    2.37667133434807,        !- Vertex 4 Y-coordinate {m}
+    3.90341289084577;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 7,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    19.1284710655839,        !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    4.00379559078073,        !- Vertex 1 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 2 X-coordinate {m}
+    2.37667133434807,        !- Vertex 2 Y-coordinate {m}
+    3.90341289084577,        !- Vertex 2 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 3 X-coordinate {m}
+    2.37667133434807,        !- Vertex 3 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 3 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    3.90379559078073;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 8,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    19.1284710655839,        !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    4.00379559078073,        !- Vertex 1 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 2 X-coordinate {m}
+    6.13906958727383,        !- Vertex 2 Y-coordinate {m}
+    3.90379559078073,        !- Vertex 2 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 3 X-coordinate {m}
+    6.13906958727383,        !- Vertex 3 Y-coordinate {m}
+    3.90379559078075,        !- Vertex 3 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    4.00379559078075;        !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ELECTRICEQUIPMENT ===========
+
+ElectricEquipment,
+    Mac,                     !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Mac,                     !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    166,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    HP,                      !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    HP,                      !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    325,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    MonitorDell,             !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    MonitorDell,             !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    166,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Fuente,                  !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Fuente,                  !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    294,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Agilent,                 !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Agilent,                 !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    25,                      !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Regulador,               !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Regulador,               !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    5,                       !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Telefono,                !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Telefono,                !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    1.5,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:SIMULATIONCONTROL ===========
+
+AirflowNetwork:SimulationControl,
+    SC ,                     !- Name
+    MultizoneWithoutDistribution,  !- AirflowNetwork Control
+    SurfaceAverageCalculation,  !- Wind Pressure Coefficient Type
+    ,                        !- Height Selection for Local Wind Pressure Calculation
+    LowRise,                 !- Building Type
+    500,                     !- Maximum Number of Iterations {dimensionless}
+    ZeroNodePressures,       !- Initialization Type
+    0.0001,                  !- Relative Airflow Convergence Tolerance {dimensionless}
+    0.000001,                !- Absolute Airflow Convergence Tolerance {kg/s}
+    -.5,                     !- Convergence Acceleration Limit {dimensionless}
+    ,                        !- Azimuth Angle of Long Axis of Building {deg}
+    1,                       !- Ratio of Building Width Along Short Axis to Width Along Long Axis
+    No,                      !- Height Dependence of External Node Temperature
+    SkylineLU,               !- Solver
+    No;                      !- Allow Unsupported Zone Equipment
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:ZONE ===========
+
+AirflowNetwork:MultiZone:Zone,
+    Cubiculo,                !- Zone Name
+    NoVent,                  !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    Standard,                !- Single Sided Wind Pressure Coefficient Algorithm
+    10;                      !- Facade Width {m}
+
+AirflowNetwork:MultiZone:Zone,
+    CubiculoTecho,           !- Zone Name
+    NoVent,                  !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    Standard,                !- Single Sided Wind Pressure Coefficient Algorithm
+    10;                      !- Facade Width {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:SURFACE ===========
+
+AirflowNetwork:MultiZone:Surface,
+    VCNI,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCNS,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    PuertaJorge,             !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCSI,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCSS,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VNT,                     !- Surface Name
+    InfiltracionTecho,       !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VST,                     !- Surface Name
+    InfiltracionTecho,       !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:REFERENCECRACKCONDITIONS ===========
+
+AirflowNetwork:MultiZone:ReferenceCrackConditions,
+    Infiltracion ,           !- Name
+    20,                      !- Reference Temperature {C}
+    86864,                   !- Reference Barometric Pressure {Pa}
+    0;                       !- Reference Humidity Ratio {kgWater/kgDryAir}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:SURFACE:CRACK ===========
+
+AirflowNetwork:MultiZone:Surface:Crack,
+    InfiltracionTecho,       !- Name
+    0.5,                     !- Air Mass Flow Coefficient at Reference Conditions {kg/s}
+    0.65,                    !- Air Mass Flow Exponent {dimensionless}
+    Infiltracion ;           !- Reference Crack Conditions
+
+AirflowNetwork:MultiZone:Surface:Crack,
+    InfiltracionCubiculo,    !- Name
+    0.01,                    !- Air Mass Flow Coefficient at Reference Conditions {kg/s}
+    0.65,                    !- Air Mass Flow Exponent {dimensionless}
+    Infiltracion ;           !- Reference Crack Conditions
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SIZING:PARAMETERS ===========
+
+Sizing:Parameters,
+    1.25,                    !- Heating Sizing Factor
+    1.15;                    !- Cooling Sizing Factor
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTDOORAIR:NODE ===========
+
+OutdoorAir:Node,
+    Model Outdoor Air Node;  !- Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:VARIABLEDICTIONARY ===========
+
+Output:VariableDictionary,
+    IDF,                     !- Key Field
+    Unsorted;                !- Sort Option
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:TABLE:SUMMARYREPORTS ===========
+
+Output:Table:SummaryReports,
+    AllSummary;              !- Report 1 Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUTCONTROL:TABLE:STYLE ===========
+
+OutputControl:Table:Style,
+    HTML;                    !- Column Separator
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:VARIABLE ===========
+
+Output:Variable,
+    Cubiculo ,               !- Key Value
+    Zone Mean Air Temperature,  !- Variable Name
+    Timestep;                !- Reporting Frequency
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:SQLITE ===========
+
+Output:SQLite,
+    SimpleAndTabular;        !- Option Type
+

--- a/PF_B2.idf
+++ b/PF_B2.idf
@@ -1,0 +1,2366 @@
+!-Generator IDFEditor 1.51
+!-Option SortedOrder
+
+!-NOTE: All comments with '!-' are ignored by the IDFEditor and are generated automatically.
+!-      Use '!' comments if they need to be retained when using the IDFEditor.
+
+
+!-   ===========  ALL OBJECTS IN CLASS: VERSION ===========
+
+Version,
+    9.5;                     !- Version Identifier
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SIMULATIONCONTROL ===========
+
+SimulationControl,
+    No,                      !- Do Zone Sizing Calculation
+    No,                      !- Do System Sizing Calculation
+    No,                      !- Do Plant Sizing Calculation
+    No,                      !- Run Simulation for Sizing Periods
+    Yes,                     !- Run Simulation for Weather File Run Periods
+    No,                      !- Do HVAC Sizing Simulation for Sizing Periods
+    1;                       !- Maximum Number of HVAC Sizing Simulation Passes
+
+
+!-   ===========  ALL OBJECTS IN CLASS: BUILDING ===========
+
+Building,
+    Building 1,              !- Name
+    ,                        !- North Axis {deg}
+    ,                        !- Terrain
+    ,                        !- Loads Convergence Tolerance Value {W}
+    ,                        !- Temperature Convergence Tolerance Value {deltaC}
+    ,                        !- Solar Distribution
+    ,                        !- Maximum Number of Warmup Days
+    ;                        !- Minimum Number of Warmup Days
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SHADOWCALCULATION ===========
+
+ShadowCalculation,
+    PolygonClipping,         !- Shading Calculation Method
+    Periodic,                !- Shading Calculation Update Frequency Method
+    20,                      !- Shading Calculation Update Frequency
+    15000,                   !- Maximum Figures in Shadow Overlap Calculations
+    SutherlandHodgman;       !- Polygon Clipping Algorithm
+
+
+!-   ===========  ALL OBJECTS IN CLASS: HEATBALANCEALGORITHM ===========
+
+HeatBalanceAlgorithm,
+    ConductionTransferFunction,  !- Algorithm
+    200;                     !- Surface Temperature Upper Limit {C}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: TIMESTEP ===========
+
+Timestep,
+    6;                       !- Number of Timesteps per Hour
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SITE:LOCATION ===========
+
+Site:Location,
+    Temixco,                 !- Name
+    18.85,                   !- Latitude {deg}
+    -99.14,                  !- Longitude {deg}
+    -6,                      !- Time Zone {hr}
+    1280;                    !- Elevation {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: RUNPERIOD ===========
+
+RunPeriod,
+    Run Period 1,            !- Name
+    5,                       !- Begin Month
+    3,                       !- Begin Day of Month
+    2019,                    !- Begin Year
+    6,                       !- End Month
+    24,                      !- End Day of Month
+    2019,                    !- End Year
+    Friday,                  !- Day of Week for Start Day
+    No,                      !- Use Weather File Holidays and Special Days
+    No,                      !- Use Weather File Daylight Saving Period
+    No,                      !- Apply Weekend Holiday Rule
+    Yes,                     !- Use Weather File Rain Indicators
+    Yes;                     !- Use Weather File Snow Indicators
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SITE:GROUNDTEMPERATURE:BUILDINGSURFACE ===========
+
+Site:GroundTemperature:BuildingSurface,
+    21,                      !- January Ground Temperature {C}
+    21,                      !- February Ground Temperature {C}
+    21,                      !- March Ground Temperature {C}
+    21,                      !- April Ground Temperature {C}
+    21,                      !- May Ground Temperature {C}
+    21,                      !- June Ground Temperature {C}
+    21,                      !- July Ground Temperature {C}
+    21,                      !- August Ground Temperature {C}
+    21,                      !- September Ground Temperature {C}
+    21,                      !- October Ground Temperature {C}
+    21,                      !- November Ground Temperature {C}
+    21;                      !- December Ground Temperature {C}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SCHEDULETYPELIMITS ===========
+
+ScheduleTypeLimits,
+    Mac,                     !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    HP,                      !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    MonitorDell,             !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Fuente,                  !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Agilent,                 !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Regulador,               !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Telefono,                !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SCHEDULE:COMPACT ===========
+
+Schedule:Compact,
+    Mac,                     !- Name
+    Mac,                     !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    HP,                      !- Name
+    HP,                      !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .02,                    !- Field 4
+    Until: 18:00,            !- Field 5
+     .4,                     !- Field 6
+    Until: 24:00,            !- Field 7
+     .02,                    !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .02,                    !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .02;                    !- Field 14
+
+Schedule:Compact,
+    MonitorDell,             !- Name
+    MonitorDell,             !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .04,                    !- Field 4
+    Until: 18:00 ,           !- Field 5
+     1,                      !- Field 6
+    Until: 24:00 ,           !- Field 7
+     .04,                    !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .04,                    !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .04;                    !- Field 14
+
+Schedule:Compact,
+    Fuente,                  !- Name
+    Fuente,                  !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .17,                    !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until:24:00,             !- Field 7
+     .17,                    !- Field 8
+    For: Weekends,           !- Field 9
+    Until:24:00,             !- Field 10
+     .17,                    !- Field 11
+    For:AllOtherDays,        !- Field 12
+    Until: 24:00,            !- Field 13
+     .17;                    !- Field 14
+
+Schedule:Compact,
+    Agilent,                 !- Name
+    Agilent,                 !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends:,          !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Regulador,               !- Name
+    Regulador,               !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Telefono,                !- Name
+    Telefono,                !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+
+!-   ===========  ALL OBJECTS IN CLASS: MATERIAL ===========
+
+Material,
+    CAD,                     !- Name
+    Rough,                   !- Roughness
+    0.1,                     !- Thickness {m}
+    2,                       !- Conductivity {W/m-K}
+    2400,                    !- Density {kg/m3}
+    10000,                   !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.6,                     !- Solar Absorptance
+    0.6;                     !- Visible Absorptance
+
+Material,
+    MorteroAltaDensidad,     !- Name
+    Rough,                   !- Roughness
+    0.1,                     !- Thickness {m}
+    0.88,                    !- Conductivity {W/m-K}
+    2800,                    !- Density {kg/m3}
+    896,                     !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.2,                     !- Solar Absorptance
+    0.2;                     !- Visible Absorptance
+
+Material,
+    Tabique,                 !- Name
+    MediumRough,             !- Roughness
+    0.14,                    !- Thickness {m}
+    0.7,                     !- Conductivity {W/m-K}
+    1970,                    !- Density {kg/m3}
+    800,                     !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.65,                    !- Solar Absorptance
+    0.65;                    !- Visible Absorptance
+
+
+!-   ===========  ALL OBJECTS IN CLASS: WINDOWMATERIAL:GLAZING ===========
+
+WindowMaterial:Glazing,
+    Clear 3mm,               !- Name
+    SpectralAverage,         !- Optical Data Type
+    ,                        !- Window Glass Spectral Data Set Name
+    0.00299999999999999,     !- Thickness {m}
+    0.837,                   !- Solar Transmittance at Normal Incidence
+    0.075,                   !- Front Side Solar Reflectance at Normal Incidence
+    0,                       !- Back Side Solar Reflectance at Normal Incidence
+    0.898,                   !- Visible Transmittance at Normal Incidence
+    0.081,                   !- Front Side Visible Reflectance at Normal Incidence
+    0,                       !- Back Side Visible Reflectance at Normal Incidence
+    0,                       !- Infrared Transmittance at Normal Incidence
+    0.84,                    !- Front Side Infrared Hemispherical Emissivity
+    0.84,                    !- Back Side Infrared Hemispherical Emissivity
+    0.9,                     !- Conductivity {W/m-K}
+    1,                       !- Dirt Correction Factor for Solar and Visible Transmittance
+    No;                      !- Solar Diffusing
+
+
+!-   ===========  ALL OBJECTS IN CLASS: CONSTRUCTION ===========
+
+Construction,
+    CAD,                     !- Name
+    CAD;                     !- Outside Layer
+
+Construction,
+    MorteroAltaDensidad,     !- Name
+    MorteroAltaDensidad;     !- Outside Layer
+
+Construction,
+    Tabique,                 !- Name
+    Tabique;                 !- Outside Layer
+
+Construction,
+    VidrioClaro3mm,          !- Name
+    Clear 3mm;               !- Outside Layer
+
+
+!-   ===========  ALL OBJECTS IN CLASS: GLOBALGEOMETRYRULES ===========
+
+GlobalGeometryRules,
+    UpperLeftCorner,         !- Starting Vertex Position
+    Counterclockwise,        !- Vertex Entry Direction
+    Relative,                !- Coordinate System
+    Relative,                !- Daylighting Reference Point Coordinate System
+    Relative;                !- Rectangular Surface Coordinate System
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ZONE ===========
+
+Zone,
+    Cubiculo,                !- Name
+    ,                        !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    CubiculoTecho,           !- Name
+    -0,                      !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    6.13906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+Zone,
+    Thermal Zone 1,          !- Name
+    ,                        !- Direction of Relative North {deg}
+    13.6484710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    Thermal Zone 4,          !- Name
+    ,                        !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    Thermal Zone 5,          !- Name
+    -0,                      !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+Zone,
+    Thermal Zone 6,          !- Name
+    -0,                      !- Direction of Relative North {deg}
+    11.0084710655839,        !- X Origin {m}
+    6.13906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ZONELIST ===========
+
+ZoneList,
+    189.1-2009 - Office - OpenOffice - CZ4-8,  !- Name
+    Cubiculo,                !- Zone 1 Name
+    CubiculoTecho,           !- Zone 2 Name
+    Thermal Zone 1,          !- Zone 3 Name
+    Thermal Zone 4,          !- Zone 4 Name
+    Thermal Zone 5,          !- Zone 5 Name
+    Thermal Zone 6;          !- Zone 6 Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: BUILDINGSURFACE:DETAILED ===========
+
+BuildingSurface:Detailed,
+    Surface 1,               !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Cubiculo,                !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 2,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 17,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 3,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 4,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 5,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 6,               !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Cubiculo,                !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 38,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 10,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 1 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 2 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773899;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 11,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 23,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0.691254272191099,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773899;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 12,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 3 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0.643980043849753,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735478;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 37,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.691254272191099,       !- Vertex 1 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    1.42622480146457e-014,   !- Vertex 2 Y-coordinate {m}
+    -2.50674674139746e-015,  !- Vertex 2 Z-coordinate {m}
+    -8.46944029798595e-031,  !- Vertex 3 X-coordinate {m}
+    1.71704131784969e-016,   !- Vertex 3 Y-coordinate {m}
+    -2.51983539825036e-015,  !- Vertex 3 Z-coordinate {m}
+    8.50457922036746e-031,   !- Vertex 4 X-coordinate {m}
+    0.691254272191099,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796446;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 38,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 6,               !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.25140085038001e-030,  !- Vertex 1 X-coordinate {m}
+    2.77288417974636e-016,   !- Vertex 1 Y-coordinate {m}
+    -1.73767408597438e-015,  !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    1.41820036321952e-014,   !- Vertex 2 Y-coordinate {m}
+    -3.44770478377269e-015,  !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 3 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 3 Z-coordinate {m}
+    2.15978859856317e-030,   !- Vertex 4 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934963;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 7,               !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 1 Y-coordinate {m}
+    -0.600382699934965,      !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 2 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934965;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 8,               !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0.691254272191099,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0.691254272191099,       !- Vertex 3 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0.643980043849753,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735478;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 9,               !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0.691254272191099,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796445;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 25,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 26,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 27,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 28,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 29,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 15,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 30,              !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 41,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 13,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 14,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 15,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 29,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 16,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 17,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 2,               !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 18,              !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 39,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 19,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    4.78869153650636e-033,   !- Vertex 1 X-coordinate {m}
+    -0.00239825292575829,    !- Vertex 1 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -0.00239825292575862,    !- Vertex 4 Y-coordinate {m}
+    -0.600382699934967;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 20,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 1 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.6334746597739;        !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 21,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 33,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    4.4512542721911,         !- Vertex 2 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.6334746597739;        !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 22,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    4.4512542721911,         !- Vertex 2 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    4.4512542721911,         !- Vertex 3 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    4.40398004384975,        !- Vertex 4 Y-coordinate {m}
+    0.406558363735487;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 23,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 11,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    4.4512542721911,         !- Vertex 4 Y-coordinate {m}
+    0.110306532796444;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 24,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 3 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    4.40398004384975,        !- Vertex 4 Y-coordinate {m}
+    0.406558363735487;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 39,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 18,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76000000000001,        !- Vertex 1 Y-coordinate {m}
+    -5.49893739466798e-015,  !- Vertex 1 Z-coordinate {m}
+    1.46653678305508e-032,   !- Vertex 2 X-coordinate {m}
+    3.76000000000001,        !- Vertex 2 Y-coordinate {m}
+    -5.68617986466966e-015,  !- Vertex 2 Z-coordinate {m}
+    -1.83366980085391e-032,  !- Vertex 3 X-coordinate {m}
+    -0.00239825292575823,    !- Vertex 3 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -0.00239825292575865,    !- Vertex 4 Y-coordinate {m}
+    -0.600382699934967;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 40,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.4512542721911,         !- Vertex 1 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76000000000001,        !- Vertex 2 Y-coordinate {m}
+    -5.05337993672583e-015,  !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76000000000001,        !- Vertex 3 Y-coordinate {m}
+    -5.05337993672583e-015,  !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    4.4512542721911,         !- Vertex 4 Y-coordinate {m}
+    0.110306532796444;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 31,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 1 Y-coordinate {m}
+    -0.600382699934981,      !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934981;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 32,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    0.691254272191086,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0.691254272191086,       !- Vertex 3 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0.643980043849737,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735468;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 33,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 21,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    0.691254272191086,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796432;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 34,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 1 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773917;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 35,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0.691254272191086,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773917;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 36,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 3 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    0.643980043849737,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735468;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 41,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 30,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -3.61448906568977e-030,  !- Vertex 1 X-coordinate {m}
+    3.51987407594703e-016,   !- Vertex 1 Y-coordinate {m}
+    -2.20578775426009e-015,  !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -3.54287221259964e-016,  !- Vertex 2 Y-coordinate {m}
+    -6.44273711449143e-015,  !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 3 Y-coordinate {m}
+    -0.600382699934983,      !- Vertex 3 Z-coordinate {m}
+    3.57836420912889e-030,   !- Vertex 4 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934979;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 42,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.691254272191086,       !- Vertex 1 Y-coordinate {m}
+    0.11030653279643,        !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -1.31014272181014e-017,  !- Vertex 2 Y-coordinate {m}
+    -6.41510049855691e-015,  !- Vertex 2 Z-coordinate {m}
+    -1.38651208186076e-031,  !- Vertex 3 X-coordinate {m}
+    1.40511909077371e-017,   !- Vertex 3 Y-coordinate {m}
+    -2.25378838828529e-015,  !- Vertex 3 Z-coordinate {m}
+    1.48976334907254e-031,   !- Vertex 4 X-coordinate {m}
+    0.691254272191086,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796434;       !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: FENESTRATIONSURFACE:DETAILED ===========
+
+FenestrationSurface:Detailed,
+    VCNI,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 3,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.34,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    2.34,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCNS,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 3,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.34,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    2.34,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    PuertaJorge,             !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.0500000000000002,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.05,                    !- Vertex 2 Z-coordinate {m}
+    0.950000000000001,       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 Z-coordinate {m}
+    0.950000000000001,       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCSI,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.98,                    !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    0.98,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    2.32,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    2.32,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCSS,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.0500000000000002,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    2.32,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    2.32,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VNT,                     !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 37,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.79,                    !- Vertex 1 X-coordinate {m}
+    0.592503661878085,       !- Vertex 1 Y-coordinate {m}
+    0.0945484566826738,      !- Vertex 1 Z-coordinate {m}
+    2.79,                    !- Vertex 2 X-coordinate {m}
+    0.345627136095554,       !- Vertex 2 Y-coordinate {m}
+    0.0551532663982288,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    0.345627136095554,       !- Vertex 3 Y-coordinate {m}
+    0.0551532663982288,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    0.592503661878085,       !- Vertex 4 Y-coordinate {m}
+    0.0945484566826738;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VST,                     !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 7,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.79,                    !- Vertex 1 X-coordinate {m}
+    -5.33253295690264,       !- Vertex 1 Y-coordinate {m}
+    -0.850936110144037,      !- Vertex 1 Z-coordinate {m}
+    2.79,                    !- Vertex 2 X-coordinate {m}
+    -5.72753539815469,       !- Vertex 2 Y-coordinate {m}
+    -0.913968414599151,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599152,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    -5.33253295690264,       !- Vertex 4 Y-coordinate {m}
+    -0.850936110144037;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 7,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.05,                    !- Vertex 2 Z-coordinate {m}
+    -1.69,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.05,                    !- Vertex 3 Z-coordinate {m}
+    -1.69,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 8,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 9,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -1.66,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -1.66,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 14,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 28,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 15,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 28,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 4,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.950000000000001,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -0.950000000000001,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 5,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    -0.98,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.98,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 6,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 12,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 16,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 13,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 16,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 17,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 19,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0500000000000002,     !- Vertex 1 X-coordinate {m}
+    -1.57253295690265,       !- Vertex 1 Y-coordinate {m}
+    -0.850936110144044,      !- Vertex 1 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 2 X-coordinate {m}
+    -1.9675353981547,        !- Vertex 2 Y-coordinate {m}
+    -0.913968414599158,      !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    -1.9675353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599158,      !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    -1.57253295690265,       !- Vertex 4 Y-coordinate {m}
+    -0.850936110144044;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 20,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 40,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0500000000000002,     !- Vertex 1 X-coordinate {m}
+    4.35250366187809,        !- Vertex 1 Y-coordinate {m}
+    0.0945484566826661,      !- Vertex 1 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 2 X-coordinate {m}
+    4.10562713609556,        !- Vertex 2 Y-coordinate {m}
+    0.0551532663982204,      !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    4.10562713609556,        !- Vertex 3 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    4.35250366187809,        !- Vertex 4 Y-coordinate {m}
+    0.094548456682666;       !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 18,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 31,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.59,                    !- Vertex 1 X-coordinate {m}
+    -5.33253295690265,       !- Vertex 1 Y-coordinate {m}
+    -0.85093611014404,       !- Vertex 1 Z-coordinate {m}
+    2.59,                    !- Vertex 2 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 2 Y-coordinate {m}
+    -0.913968414599155,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599155,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    -5.33253295690265,       !- Vertex 4 Y-coordinate {m}
+    -0.85093611014404;       !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 21,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 42,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.59,                    !- Vertex 1 X-coordinate {m}
+    0.592503661878087,       !- Vertex 1 Y-coordinate {m}
+    0.0945484566826618,      !- Vertex 1 Z-coordinate {m}
+    2.59,                    !- Vertex 2 X-coordinate {m}
+    0.345627136095556,       !- Vertex 2 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    0.345627136095556,       !- Vertex 3 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    0.592503661878087,       !- Vertex 4 Y-coordinate {m}
+    0.0945484566826618;      !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SHADING:BUILDING:DETAILED ===========
+
+Shading:Building:Detailed,
+    Shading Surface 1,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    4.9284710655839,         !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    5.40379559078073,        !- Vertex 1 Z-coordinate {m}
+    4.9284710655839,         !- Vertex 2 X-coordinate {m}
+    0.8868915534472,         !- Vertex 2 Y-coordinate {m}
+    3.46095594197053,        !- Vertex 2 Z-coordinate {m}
+    18.1284710655839,        !- Vertex 3 X-coordinate {m}
+    0.8868915534472,         !- Vertex 3 Y-coordinate {m}
+    3.46095594197053,        !- Vertex 3 Z-coordinate {m}
+    18.1284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    5.40379559078073;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 4,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    21.9884710655839,        !- Vertex 1 X-coordinate {m}
+    3.61703301654305,        !- Vertex 1 Y-coordinate {m}
+    4.72,                    !- Vertex 1 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 2 X-coordinate {m}
+    3.61703301654305,        !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 3 X-coordinate {m}
+    -4.05296698345695,       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 4 X-coordinate {m}
+    -4.05296698345695,       !- Vertex 4 Y-coordinate {m}
+    4.72;                    !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 5,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    24.1261916075609,        !- Vertex 1 X-coordinate {m}
+    4.91323935984245,        !- Vertex 1 Y-coordinate {m}
+    4.72,                    !- Vertex 1 Z-coordinate {m}
+    24.1261916075609,        !- Vertex 2 X-coordinate {m}
+    4.91323935984245,        !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 3 X-coordinate {m}
+    3.61703301654305,        !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 4 X-coordinate {m}
+    3.61703301654305,        !- Vertex 4 Y-coordinate {m}
+    4.72;                    !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 6,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    18.6284710655839,        !- Vertex 1 X-coordinate {m}
+    2.37667133434807,        !- Vertex 1 Y-coordinate {m}
+    3.90341289084577,        !- Vertex 1 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 2 X-coordinate {m}
+    2.37667133434807,        !- Vertex 2 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 2 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 3 X-coordinate {m}
+    2.37667133434807,        !- Vertex 3 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 3 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 4 X-coordinate {m}
+    2.37667133434807,        !- Vertex 4 Y-coordinate {m}
+    3.90341289084577;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 7,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    19.1284710655839,        !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    4.00379559078073,        !- Vertex 1 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 2 X-coordinate {m}
+    2.37667133434807,        !- Vertex 2 Y-coordinate {m}
+    3.90341289084577,        !- Vertex 2 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 3 X-coordinate {m}
+    2.37667133434807,        !- Vertex 3 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 3 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    3.90379559078073;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 8,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    19.1284710655839,        !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    4.00379559078073,        !- Vertex 1 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 2 X-coordinate {m}
+    6.13906958727383,        !- Vertex 2 Y-coordinate {m}
+    3.90379559078073,        !- Vertex 2 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 3 X-coordinate {m}
+    6.13906958727383,        !- Vertex 3 Y-coordinate {m}
+    3.90379559078075,        !- Vertex 3 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    4.00379559078075;        !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ELECTRICEQUIPMENT ===========
+
+ElectricEquipment,
+    Mac,                     !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Mac,                     !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    166,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    0.1,                     !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    HP,                      !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    HP,                      !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    325,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    0.1,                     !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    MonitorDell,             !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    MonitorDell,             !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    166,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    0.35,                    !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Fuente,                  !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Fuente,                  !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    294,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Agilent,                 !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Agilent,                 !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    25,                      !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Regulador,               !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Regulador,               !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    5,                       !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Telefono,                !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Telefono,                !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    1.5,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:SIMULATIONCONTROL ===========
+
+AirflowNetwork:SimulationControl,
+    SC ,                     !- Name
+    MultizoneWithoutDistribution,  !- AirflowNetwork Control
+    SurfaceAverageCalculation,  !- Wind Pressure Coefficient Type
+    ,                        !- Height Selection for Local Wind Pressure Calculation
+    LowRise,                 !- Building Type
+    500,                     !- Maximum Number of Iterations {dimensionless}
+    ZeroNodePressures,       !- Initialization Type
+    0.0001,                  !- Relative Airflow Convergence Tolerance {dimensionless}
+    0.000001,                !- Absolute Airflow Convergence Tolerance {kg/s}
+    -.5,                     !- Convergence Acceleration Limit {dimensionless}
+    ,                        !- Azimuth Angle of Long Axis of Building {deg}
+    1,                       !- Ratio of Building Width Along Short Axis to Width Along Long Axis
+    No,                      !- Height Dependence of External Node Temperature
+    SkylineLU,               !- Solver
+    No;                      !- Allow Unsupported Zone Equipment
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:ZONE ===========
+
+AirflowNetwork:MultiZone:Zone,
+    Cubiculo,                !- Zone Name
+    NoVent,                  !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    Standard,                !- Single Sided Wind Pressure Coefficient Algorithm
+    10;                      !- Facade Width {m}
+
+AirflowNetwork:MultiZone:Zone,
+    CubiculoTecho,           !- Zone Name
+    NoVent,                  !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    Standard,                !- Single Sided Wind Pressure Coefficient Algorithm
+    10;                      !- Facade Width {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:SURFACE ===========
+
+AirflowNetwork:MultiZone:Surface,
+    VCNI,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCNS,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    PuertaJorge,             !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCSI,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCSS,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VNT,                     !- Surface Name
+    InfiltracionTecho,       !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VST,                     !- Surface Name
+    InfiltracionTecho,       !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:REFERENCECRACKCONDITIONS ===========
+
+AirflowNetwork:MultiZone:ReferenceCrackConditions,
+    Infiltracion ,           !- Name
+    20,                      !- Reference Temperature {C}
+    86864,                   !- Reference Barometric Pressure {Pa}
+    0;                       !- Reference Humidity Ratio {kgWater/kgDryAir}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:SURFACE:CRACK ===========
+
+AirflowNetwork:MultiZone:Surface:Crack,
+    InfiltracionTecho,       !- Name
+    0.5,                     !- Air Mass Flow Coefficient at Reference Conditions {kg/s}
+    0.65,                    !- Air Mass Flow Exponent {dimensionless}
+    Infiltracion ;           !- Reference Crack Conditions
+
+AirflowNetwork:MultiZone:Surface:Crack,
+    InfiltracionCubiculo,    !- Name
+    0.01,                    !- Air Mass Flow Coefficient at Reference Conditions {kg/s}
+    0.65,                    !- Air Mass Flow Exponent {dimensionless}
+    Infiltracion ;           !- Reference Crack Conditions
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SIZING:PARAMETERS ===========
+
+Sizing:Parameters,
+    1.25,                    !- Heating Sizing Factor
+    1.15;                    !- Cooling Sizing Factor
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTDOORAIR:NODE ===========
+
+OutdoorAir:Node,
+    Model Outdoor Air Node;  !- Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:VARIABLEDICTIONARY ===========
+
+Output:VariableDictionary,
+    IDF,                     !- Key Field
+    Unsorted;                !- Sort Option
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:TABLE:SUMMARYREPORTS ===========
+
+Output:Table:SummaryReports,
+    AllSummary;              !- Report 1 Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUTCONTROL:TABLE:STYLE ===========
+
+OutputControl:Table:Style,
+    HTML;                    !- Column Separator
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:VARIABLE ===========
+
+Output:Variable,
+    Cubiculo ,               !- Key Value
+    Zone Mean Air Temperature,  !- Variable Name
+    Timestep;                !- Reporting Frequency
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:SQLITE ===========
+
+Output:SQLite,
+    SimpleAndTabular;        !- Option Type
+

--- a/PF_B3.idf
+++ b/PF_B3.idf
@@ -1,0 +1,2366 @@
+!-Generator IDFEditor 1.51
+!-Option SortedOrder
+
+!-NOTE: All comments with '!-' are ignored by the IDFEditor and are generated automatically.
+!-      Use '!' comments if they need to be retained when using the IDFEditor.
+
+
+!-   ===========  ALL OBJECTS IN CLASS: VERSION ===========
+
+Version,
+    9.5;                     !- Version Identifier
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SIMULATIONCONTROL ===========
+
+SimulationControl,
+    No,                      !- Do Zone Sizing Calculation
+    No,                      !- Do System Sizing Calculation
+    No,                      !- Do Plant Sizing Calculation
+    No,                      !- Run Simulation for Sizing Periods
+    Yes,                     !- Run Simulation for Weather File Run Periods
+    No,                      !- Do HVAC Sizing Simulation for Sizing Periods
+    1;                       !- Maximum Number of HVAC Sizing Simulation Passes
+
+
+!-   ===========  ALL OBJECTS IN CLASS: BUILDING ===========
+
+Building,
+    Building 1,              !- Name
+    ,                        !- North Axis {deg}
+    ,                        !- Terrain
+    ,                        !- Loads Convergence Tolerance Value {W}
+    ,                        !- Temperature Convergence Tolerance Value {deltaC}
+    ,                        !- Solar Distribution
+    ,                        !- Maximum Number of Warmup Days
+    ;                        !- Minimum Number of Warmup Days
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SHADOWCALCULATION ===========
+
+ShadowCalculation,
+    PolygonClipping,         !- Shading Calculation Method
+    Periodic,                !- Shading Calculation Update Frequency Method
+    20,                      !- Shading Calculation Update Frequency
+    15000,                   !- Maximum Figures in Shadow Overlap Calculations
+    SutherlandHodgman;       !- Polygon Clipping Algorithm
+
+
+!-   ===========  ALL OBJECTS IN CLASS: HEATBALANCEALGORITHM ===========
+
+HeatBalanceAlgorithm,
+    ConductionTransferFunction,  !- Algorithm
+    200;                     !- Surface Temperature Upper Limit {C}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: TIMESTEP ===========
+
+Timestep,
+    6;                       !- Number of Timesteps per Hour
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SITE:LOCATION ===========
+
+Site:Location,
+    Temixco,                 !- Name
+    18.85,                   !- Latitude {deg}
+    -99.14,                  !- Longitude {deg}
+    -6,                      !- Time Zone {hr}
+    1280;                    !- Elevation {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: RUNPERIOD ===========
+
+RunPeriod,
+    Run Period 1,            !- Name
+    5,                       !- Begin Month
+    3,                       !- Begin Day of Month
+    2019,                    !- Begin Year
+    6,                       !- End Month
+    24,                      !- End Day of Month
+    2019,                    !- End Year
+    Friday,                  !- Day of Week for Start Day
+    No,                      !- Use Weather File Holidays and Special Days
+    No,                      !- Use Weather File Daylight Saving Period
+    No,                      !- Apply Weekend Holiday Rule
+    Yes,                     !- Use Weather File Rain Indicators
+    Yes;                     !- Use Weather File Snow Indicators
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SITE:GROUNDTEMPERATURE:BUILDINGSURFACE ===========
+
+Site:GroundTemperature:BuildingSurface,
+    21,                      !- January Ground Temperature {C}
+    21,                      !- February Ground Temperature {C}
+    21,                      !- March Ground Temperature {C}
+    21,                      !- April Ground Temperature {C}
+    21,                      !- May Ground Temperature {C}
+    21,                      !- June Ground Temperature {C}
+    21,                      !- July Ground Temperature {C}
+    21,                      !- August Ground Temperature {C}
+    21,                      !- September Ground Temperature {C}
+    21,                      !- October Ground Temperature {C}
+    21,                      !- November Ground Temperature {C}
+    21;                      !- December Ground Temperature {C}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SCHEDULETYPELIMITS ===========
+
+ScheduleTypeLimits,
+    Mac,                     !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    HP,                      !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    MonitorDell,             !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Fuente,                  !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Agilent,                 !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Regulador,               !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+ScheduleTypeLimits,
+    Telefono,                !- Name
+    ,                        !- Lower Limit Value
+    ,                        !- Upper Limit Value
+    Discrete,                !- Numeric Type
+    Percent;                 !- Unit Type
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SCHEDULE:COMPACT ===========
+
+Schedule:Compact,
+    Mac,                     !- Name
+    Mac,                     !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    HP,                      !- Name
+    HP,                      !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .02,                    !- Field 4
+    Until: 18:00,            !- Field 5
+     .4,                     !- Field 6
+    Until: 24:00,            !- Field 7
+     .02,                    !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .02,                    !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .02;                    !- Field 14
+
+Schedule:Compact,
+    MonitorDell,             !- Name
+    MonitorDell,             !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .04,                    !- Field 4
+    Until: 18:00 ,           !- Field 5
+     1,                      !- Field 6
+    Until: 24:00 ,           !- Field 7
+     .04,                    !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .04,                    !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .04;                    !- Field 14
+
+Schedule:Compact,
+    Fuente,                  !- Name
+    Fuente,                  !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .17,                    !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until:24:00,             !- Field 7
+     .17,                    !- Field 8
+    For: Weekends,           !- Field 9
+    Until:24:00,             !- Field 10
+     .17,                    !- Field 11
+    For:AllOtherDays,        !- Field 12
+    Until: 24:00,            !- Field 13
+     .17;                    !- Field 14
+
+Schedule:Compact,
+    Agilent,                 !- Name
+    Agilent,                 !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends:,          !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Regulador,               !- Name
+    Regulador,               !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until:24:00,             !- Field 13
+     .2;                     !- Field 14
+
+Schedule:Compact,
+    Telefono,                !- Name
+    Telefono,                !- Schedule Type Limits Name
+    Through: 12/31,          !- Field 1
+    For: Weekdays,           !- Field 2
+    Until: 9:00,             !- Field 3
+     .2,                     !- Field 4
+    Until: 18:00,            !- Field 5
+     1,                      !- Field 6
+    Until: 24:00,            !- Field 7
+     .2,                     !- Field 8
+    For: Weekends,           !- Field 9
+    Until: 24:00,            !- Field 10
+     .2,                     !- Field 11
+    For: AllOtherDays,       !- Field 12
+    Until: 24:00,            !- Field 13
+     .2;                     !- Field 14
+
+
+!-   ===========  ALL OBJECTS IN CLASS: MATERIAL ===========
+
+Material,
+    CAD,                     !- Name
+    Rough,                   !- Roughness
+    0.1,                     !- Thickness {m}
+    2,                       !- Conductivity {W/m-K}
+    2400,                    !- Density {kg/m3}
+    10000,                   !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.6,                     !- Solar Absorptance
+    0.6;                     !- Visible Absorptance
+
+Material,
+    MorteroAltaDensidad,     !- Name
+    Rough,                   !- Roughness
+    0.1,                     !- Thickness {m}
+    0.88,                    !- Conductivity {W/m-K}
+    2800,                    !- Density {kg/m3}
+    896,                     !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.2,                     !- Solar Absorptance
+    0.2;                     !- Visible Absorptance
+
+Material,
+    Tabique,                 !- Name
+    MediumRough,             !- Roughness
+    0.14,                    !- Thickness {m}
+    0.7,                     !- Conductivity {W/m-K}
+    1970,                    !- Density {kg/m3}
+    800,                     !- Specific Heat {J/kg-K}
+    0.9,                     !- Thermal Absorptance
+    0.65,                    !- Solar Absorptance
+    0.65;                    !- Visible Absorptance
+
+
+!-   ===========  ALL OBJECTS IN CLASS: WINDOWMATERIAL:GLAZING ===========
+
+WindowMaterial:Glazing,
+    Clear 3mm,               !- Name
+    SpectralAverage,         !- Optical Data Type
+    ,                        !- Window Glass Spectral Data Set Name
+    0.00299999999999999,     !- Thickness {m}
+    0.837,                   !- Solar Transmittance at Normal Incidence
+    0.075,                   !- Front Side Solar Reflectance at Normal Incidence
+    0,                       !- Back Side Solar Reflectance at Normal Incidence
+    0.898,                   !- Visible Transmittance at Normal Incidence
+    0.081,                   !- Front Side Visible Reflectance at Normal Incidence
+    0,                       !- Back Side Visible Reflectance at Normal Incidence
+    0,                       !- Infrared Transmittance at Normal Incidence
+    0.84,                    !- Front Side Infrared Hemispherical Emissivity
+    0.84,                    !- Back Side Infrared Hemispherical Emissivity
+    0.9,                     !- Conductivity {W/m-K}
+    1,                       !- Dirt Correction Factor for Solar and Visible Transmittance
+    No;                      !- Solar Diffusing
+
+
+!-   ===========  ALL OBJECTS IN CLASS: CONSTRUCTION ===========
+
+Construction,
+    CAD,                     !- Name
+    CAD;                     !- Outside Layer
+
+Construction,
+    MorteroAltaDensidad,     !- Name
+    MorteroAltaDensidad;     !- Outside Layer
+
+Construction,
+    Tabique,                 !- Name
+    Tabique;                 !- Outside Layer
+
+Construction,
+    VidrioClaro3mm,          !- Name
+    Clear 3mm;               !- Outside Layer
+
+
+!-   ===========  ALL OBJECTS IN CLASS: GLOBALGEOMETRYRULES ===========
+
+GlobalGeometryRules,
+    UpperLeftCorner,         !- Starting Vertex Position
+    Counterclockwise,        !- Vertex Entry Direction
+    Relative,                !- Coordinate System
+    Relative,                !- Daylighting Reference Point Coordinate System
+    Relative;                !- Rectangular Surface Coordinate System
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ZONE ===========
+
+Zone,
+    Cubiculo,                !- Name
+    ,                        !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    CubiculoTecho,           !- Name
+    -0,                      !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    6.13906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+Zone,
+    Thermal Zone 1,          !- Name
+    ,                        !- Direction of Relative North {deg}
+    13.6484710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    Thermal Zone 4,          !- Name
+    ,                        !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    0;                       !- Z Origin {m}
+
+Zone,
+    Thermal Zone 5,          !- Name
+    -0,                      !- Direction of Relative North {deg}
+    16.2884710655839,        !- X Origin {m}
+    2.37906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+Zone,
+    Thermal Zone 6,          !- Name
+    -0,                      !- Direction of Relative North {deg}
+    11.0084710655839,        !- X Origin {m}
+    6.13906958727382,        !- Y Origin {m}
+    3.6;                     !- Z Origin {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ZONELIST ===========
+
+ZoneList,
+    189.1-2009 - Office - OpenOffice - CZ4-8,  !- Name
+    Cubiculo,                !- Zone 1 Name
+    CubiculoTecho,           !- Zone 2 Name
+    Thermal Zone 1,          !- Zone 3 Name
+    Thermal Zone 4,          !- Zone 4 Name
+    Thermal Zone 5,          !- Zone 5 Name
+    Thermal Zone 6;          !- Zone 6 Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: BUILDINGSURFACE:DETAILED ===========
+
+BuildingSurface:Detailed,
+    Surface 1,               !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Cubiculo,                !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 2,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 17,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 3,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 4,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 5,               !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Cubiculo,                !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 6,               !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Cubiculo,                !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 38,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 10,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 1 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 2 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773899;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 11,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 23,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0.691254272191099,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773899;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 12,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 3 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0.643980043849753,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735478;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 37,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.691254272191099,       !- Vertex 1 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    1.42622480146457e-014,   !- Vertex 2 Y-coordinate {m}
+    -2.50674674139746e-015,  !- Vertex 2 Z-coordinate {m}
+    -8.46944029798595e-031,  !- Vertex 3 X-coordinate {m}
+    1.71704131784969e-016,   !- Vertex 3 Y-coordinate {m}
+    -2.51983539825036e-015,  !- Vertex 3 Z-coordinate {m}
+    8.50457922036746e-031,   !- Vertex 4 X-coordinate {m}
+    0.691254272191099,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796446;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 38,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 6,               !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.25140085038001e-030,  !- Vertex 1 X-coordinate {m}
+    2.77288417974636e-016,   !- Vertex 1 Y-coordinate {m}
+    -1.73767408597438e-015,  !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    1.41820036321952e-014,   !- Vertex 2 Y-coordinate {m}
+    -3.44770478377269e-015,  !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 3 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 3 Z-coordinate {m}
+    2.15978859856317e-030,   !- Vertex 4 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934963;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 7,               !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 1 Y-coordinate {m}
+    -0.600382699934965,      !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 2 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -3.76239825292575,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934965;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 8,               !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    0.691254272191099,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0.691254272191099,       !- Vertex 3 Y-coordinate {m}
+    0.110306532796445,       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0.643980043849753,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735478;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 9,               !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    CubiculoTecho,           !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.84,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849753,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735478,       !- Vertex 1 Z-coordinate {m}
+    2.84,                    !- Vertex 2 X-coordinate {m}
+    -5.87356023680904,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773899,      !- Vertex 2 Z-coordinate {m}
+    2.84,                    !- Vertex 3 X-coordinate {m}
+    -5.8262860084677,        !- Vertex 3 Y-coordinate {m}
+    -0.929726490712935,      !- Vertex 3 Z-coordinate {m}
+    2.84,                    !- Vertex 4 X-coordinate {m}
+    0.691254272191099,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796445;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 25,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 26,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 27,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 28,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 29,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 15,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 30,              !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 1,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 41,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 13,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Ground,                  !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    0,                       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 14,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    3,                       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 15,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 29,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    3;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 16,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 17,              !- Name
+    Wall,                    !- Surface Type
+    Tabique,                 !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 2,               !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    0;                       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 18,              !- Name
+    Ceiling,                 !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 4,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 39,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    3,                       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    3,                       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.6;                     !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 19,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    4.78869153650636e-033,   !- Vertex 1 X-coordinate {m}
+    -0.00239825292575829,    !- Vertex 1 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -0.00239825292575862,    !- Vertex 4 Y-coordinate {m}
+    -0.600382699934967;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 20,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 1 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.6334746597739;        !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 21,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 33,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    4.4512542721911,         !- Vertex 2 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.6334746597739;        !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 22,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    4.4512542721911,         !- Vertex 2 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    4.4512542721911,         !- Vertex 3 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    4.40398004384975,        !- Vertex 4 Y-coordinate {m}
+    0.406558363735487;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 23,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 11,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.06628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712936,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    4.4512542721911,         !- Vertex 4 Y-coordinate {m}
+    0.110306532796444;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 24,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    4.40398004384975,        !- Vertex 1 Y-coordinate {m}
+    0.406558363735487,       !- Vertex 1 Z-coordinate {m}
+    -2.64,                   !- Vertex 2 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -2.11356023680905,       !- Vertex 3 Y-coordinate {m}
+    -0.6334746597739,        !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    4.40398004384975,        !- Vertex 4 Y-coordinate {m}
+    0.406558363735487;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 39,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 18,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -2.64,                   !- Vertex 1 X-coordinate {m}
+    3.76000000000001,        !- Vertex 1 Y-coordinate {m}
+    -5.49893739466798e-015,  !- Vertex 1 Z-coordinate {m}
+    1.46653678305508e-032,   !- Vertex 2 X-coordinate {m}
+    3.76000000000001,        !- Vertex 2 Y-coordinate {m}
+    -5.68617986466966e-015,  !- Vertex 2 Z-coordinate {m}
+    -1.83366980085391e-032,  !- Vertex 3 X-coordinate {m}
+    -0.00239825292575823,    !- Vertex 3 Y-coordinate {m}
+    -0.600382699934967,      !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    -0.00239825292575865,    !- Vertex 4 Y-coordinate {m}
+    -0.600382699934967;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 40,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 5,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    4.4512542721911,         !- Vertex 1 Y-coordinate {m}
+    0.110306532796444,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    3.76000000000001,        !- Vertex 2 Y-coordinate {m}
+    -5.05337993672583e-015,  !- Vertex 2 Z-coordinate {m}
+    -2.64,                   !- Vertex 3 X-coordinate {m}
+    3.76000000000001,        !- Vertex 3 Y-coordinate {m}
+    -5.05337993672583e-015,  !- Vertex 3 Z-coordinate {m}
+    -2.64,                   !- Vertex 4 X-coordinate {m}
+    4.4512542721911,         !- Vertex 4 Y-coordinate {m}
+    0.110306532796444;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 31,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 1 Y-coordinate {m}
+    -0.600382699934981,      !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934981;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 32,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    0.691254272191086,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    0.691254272191086,       !- Vertex 3 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    0.643980043849737,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735468;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 33,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 21,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    0.691254272191086,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796432;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 34,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 1 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 2 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773917;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 35,              !- Name
+    Wall,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    0.691254272191086,       !- Vertex 2 Y-coordinate {m}
+    0.110306532796432,       !- Vertex 2 Z-coordinate {m}
+    0,                       !- Vertex 3 X-coordinate {m}
+    -5.82628600846771,       !- Vertex 3 Y-coordinate {m}
+    -0.929726490712952,      !- Vertex 3 Z-coordinate {m}
+    0,                       !- Vertex 4 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 4 Y-coordinate {m}
+    -0.633474659773917;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 36,              !- Name
+    Roof,                    !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    0,                       !- Vertex 1 X-coordinate {m}
+    0.643980043849737,       !- Vertex 1 Y-coordinate {m}
+    0.406558363735468,       !- Vertex 1 Z-coordinate {m}
+    0,                       !- Vertex 2 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 2 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -5.87356023680905,       !- Vertex 3 Y-coordinate {m}
+    -0.633474659773917,      !- Vertex 3 Z-coordinate {m}
+    2.64,                    !- Vertex 4 X-coordinate {m}
+    0.643980043849737,       !- Vertex 4 Y-coordinate {m}
+    0.406558363735468;       !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 41,              !- Name
+    Floor,                   !- Surface Type
+    CAD,                     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Surface,                 !- Outside Boundary Condition
+    Surface 30,              !- Outside Boundary Condition Object
+    NoSun,                   !- Sun Exposure
+    NoWind,                  !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    -3.61448906568977e-030,  !- Vertex 1 X-coordinate {m}
+    3.51987407594703e-016,   !- Vertex 1 Y-coordinate {m}
+    -2.20578775426009e-015,  !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -3.54287221259964e-016,  !- Vertex 2 Y-coordinate {m}
+    -6.44273711449143e-015,  !- Vertex 2 Z-coordinate {m}
+    2.64,                    !- Vertex 3 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 3 Y-coordinate {m}
+    -0.600382699934983,      !- Vertex 3 Z-coordinate {m}
+    3.57836420912889e-030,   !- Vertex 4 X-coordinate {m}
+    -3.76239825292576,       !- Vertex 4 Y-coordinate {m}
+    -0.600382699934979;      !- Vertex 4 Z-coordinate {m}
+
+BuildingSurface:Detailed,
+    Surface 42,              !- Name
+    Floor,                   !- Surface Type
+    MorteroAltaDensidad,     !- Construction Name
+    Thermal Zone 6,          !- Zone Name
+    Outdoors,                !- Outside Boundary Condition
+    ,                        !- Outside Boundary Condition Object
+    SunExposed,              !- Sun Exposure
+    WindExposed,             !- Wind Exposure
+    ,                        !- View Factor to Ground
+    ,                        !- Number of Vertices
+    2.64,                    !- Vertex 1 X-coordinate {m}
+    0.691254272191086,       !- Vertex 1 Y-coordinate {m}
+    0.11030653279643,        !- Vertex 1 Z-coordinate {m}
+    2.64,                    !- Vertex 2 X-coordinate {m}
+    -1.31014272181014e-017,  !- Vertex 2 Y-coordinate {m}
+    -6.41510049855691e-015,  !- Vertex 2 Z-coordinate {m}
+    -1.38651208186076e-031,  !- Vertex 3 X-coordinate {m}
+    1.40511909077371e-017,   !- Vertex 3 Y-coordinate {m}
+    -2.25378838828529e-015,  !- Vertex 3 Z-coordinate {m}
+    1.48976334907254e-031,   !- Vertex 4 X-coordinate {m}
+    0.691254272191086,       !- Vertex 4 Y-coordinate {m}
+    0.110306532796434;       !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: FENESTRATIONSURFACE:DETAILED ===========
+
+FenestrationSurface:Detailed,
+    VCNI,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 3,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.34,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    2.34,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCNS,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 3,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.34,                    !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    2.34,                    !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    0.0500000000000031,      !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    PuertaJorge,             !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.0500000000000002,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.05,                    !- Vertex 2 Z-coordinate {m}
+    0.950000000000001,       !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 Z-coordinate {m}
+    0.950000000000001,       !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCSI,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.98,                    !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    0.98,                    !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    2.32,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    2.32,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VCSS,                    !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 5,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    0.0500000000000002,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    2.32,                    !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    2.32,                    !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VNT,                     !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 37,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.79,                    !- Vertex 1 X-coordinate {m}
+    0.592503661878085,       !- Vertex 1 Y-coordinate {m}
+    0.0945484566826738,      !- Vertex 1 Z-coordinate {m}
+    2.79,                    !- Vertex 2 X-coordinate {m}
+    0.345627136095554,       !- Vertex 2 Y-coordinate {m}
+    0.0551532663982288,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    0.345627136095554,       !- Vertex 3 Y-coordinate {m}
+    0.0551532663982288,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    0.592503661878085,       !- Vertex 4 Y-coordinate {m}
+    0.0945484566826738;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    VST,                     !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 7,               !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.79,                    !- Vertex 1 X-coordinate {m}
+    -5.33253295690264,       !- Vertex 1 Y-coordinate {m}
+    -0.850936110144037,      !- Vertex 1 Z-coordinate {m}
+    2.79,                    !- Vertex 2 X-coordinate {m}
+    -5.72753539815469,       !- Vertex 2 Y-coordinate {m}
+    -0.913968414599151,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599152,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    -5.33253295690264,       !- Vertex 4 Y-coordinate {m}
+    -0.850936110144037;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 7,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.05,                    !- Vertex 2 Z-coordinate {m}
+    -1.69,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.05,                    !- Vertex 3 Z-coordinate {m}
+    -1.69,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 8,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 9,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 26,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -1.66,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -1.66,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 14,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 28,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 15,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 28,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 4,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.950000000000001,      !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -0.950000000000001,      !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    0.0500000000000002,      !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    0.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 5,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.15,                    !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    1.05,                    !- Vertex 2 Z-coordinate {m}
+    -0.98,                   !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    1.05,                    !- Vertex 3 Z-coordinate {m}
+    -0.98,                   !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.15;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 6,           !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 14,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -2.59,                   !- Vertex 1 X-coordinate {m}
+    0,                       !- Vertex 1 Y-coordinate {m}
+    2.6,                     !- Vertex 1 Z-coordinate {m}
+    -2.59,                   !- Vertex 2 X-coordinate {m}
+    0,                       !- Vertex 2 Y-coordinate {m}
+    2.2,                     !- Vertex 2 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 3 X-coordinate {m}
+    0,                       !- Vertex 3 Y-coordinate {m}
+    2.2,                     !- Vertex 3 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 4 X-coordinate {m}
+    0,                       !- Vertex 4 Y-coordinate {m}
+    2.6;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 12,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 16,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    3.1,                     !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    2.1,                     !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    2.1,                     !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    3.1;                     !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 13,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 16,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0499999999999973,     !- Vertex 1 X-coordinate {m}
+    3.76,                    !- Vertex 1 Y-coordinate {m}
+    2.05,                    !- Vertex 1 Z-coordinate {m}
+    -0.0499999999999973,     !- Vertex 2 X-coordinate {m}
+    3.76,                    !- Vertex 2 Y-coordinate {m}
+    1,                       !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    3.76,                    !- Vertex 3 Y-coordinate {m}
+    1,                       !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    3.76,                    !- Vertex 4 Y-coordinate {m}
+    2.05;                    !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 17,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 19,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0500000000000002,     !- Vertex 1 X-coordinate {m}
+    -1.57253295690265,       !- Vertex 1 Y-coordinate {m}
+    -0.850936110144044,      !- Vertex 1 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 2 X-coordinate {m}
+    -1.9675353981547,        !- Vertex 2 Y-coordinate {m}
+    -0.913968414599158,      !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    -1.9675353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599158,      !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    -1.57253295690265,       !- Vertex 4 Y-coordinate {m}
+    -0.850936110144044;      !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 20,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 40,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    -0.0500000000000002,     !- Vertex 1 X-coordinate {m}
+    4.35250366187809,        !- Vertex 1 Y-coordinate {m}
+    0.0945484566826661,      !- Vertex 1 Z-coordinate {m}
+    -0.0500000000000002,     !- Vertex 2 X-coordinate {m}
+    4.10562713609556,        !- Vertex 2 Y-coordinate {m}
+    0.0551532663982204,      !- Vertex 2 Z-coordinate {m}
+    -2.59,                   !- Vertex 3 X-coordinate {m}
+    4.10562713609556,        !- Vertex 3 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 3 Z-coordinate {m}
+    -2.59,                   !- Vertex 4 X-coordinate {m}
+    4.35250366187809,        !- Vertex 4 Y-coordinate {m}
+    0.094548456682666;       !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 18,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 31,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.59,                    !- Vertex 1 X-coordinate {m}
+    -5.33253295690265,       !- Vertex 1 Y-coordinate {m}
+    -0.85093611014404,       !- Vertex 1 Z-coordinate {m}
+    2.59,                    !- Vertex 2 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 2 Y-coordinate {m}
+    -0.913968414599155,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    -5.7275353981547,        !- Vertex 3 Y-coordinate {m}
+    -0.913968414599155,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    -5.33253295690265,       !- Vertex 4 Y-coordinate {m}
+    -0.85093611014404;       !- Vertex 4 Z-coordinate {m}
+
+FenestrationSurface:Detailed,
+    Sub Surface 21,          !- Name
+    Window,                  !- Surface Type
+    VidrioClaro3mm,          !- Construction Name
+    Surface 42,              !- Building Surface Name
+    ,                        !- Outside Boundary Condition Object
+    ,                        !- View Factor to Ground
+    ,                        !- Frame and Divider Name
+    ,                        !- Multiplier
+    ,                        !- Number of Vertices
+    2.59,                    !- Vertex 1 X-coordinate {m}
+    0.592503661878087,       !- Vertex 1 Y-coordinate {m}
+    0.0945484566826618,      !- Vertex 1 Z-coordinate {m}
+    2.59,                    !- Vertex 2 X-coordinate {m}
+    0.345627136095556,       !- Vertex 2 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 2 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 3 X-coordinate {m}
+    0.345627136095556,       !- Vertex 3 Y-coordinate {m}
+    0.0551532663982203,      !- Vertex 3 Z-coordinate {m}
+    0.0500000000000002,      !- Vertex 4 X-coordinate {m}
+    0.592503661878087,       !- Vertex 4 Y-coordinate {m}
+    0.0945484566826618;      !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SHADING:BUILDING:DETAILED ===========
+
+Shading:Building:Detailed,
+    Shading Surface 1,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    4.9284710655839,         !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    5.40379559078073,        !- Vertex 1 Z-coordinate {m}
+    4.9284710655839,         !- Vertex 2 X-coordinate {m}
+    0.8868915534472,         !- Vertex 2 Y-coordinate {m}
+    3.46095594197053,        !- Vertex 2 Z-coordinate {m}
+    18.1284710655839,        !- Vertex 3 X-coordinate {m}
+    0.8868915534472,         !- Vertex 3 Y-coordinate {m}
+    3.46095594197053,        !- Vertex 3 Z-coordinate {m}
+    18.1284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    5.40379559078073;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 4,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    21.9884710655839,        !- Vertex 1 X-coordinate {m}
+    3.61703301654305,        !- Vertex 1 Y-coordinate {m}
+    4.72,                    !- Vertex 1 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 2 X-coordinate {m}
+    3.61703301654305,        !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 3 X-coordinate {m}
+    -4.05296698345695,       !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 4 X-coordinate {m}
+    -4.05296698345695,       !- Vertex 4 Y-coordinate {m}
+    4.72;                    !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 5,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    24.1261916075609,        !- Vertex 1 X-coordinate {m}
+    4.91323935984245,        !- Vertex 1 Y-coordinate {m}
+    4.72,                    !- Vertex 1 Z-coordinate {m}
+    24.1261916075609,        !- Vertex 2 X-coordinate {m}
+    4.91323935984245,        !- Vertex 2 Y-coordinate {m}
+    0,                       !- Vertex 2 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 3 X-coordinate {m}
+    3.61703301654305,        !- Vertex 3 Y-coordinate {m}
+    0,                       !- Vertex 3 Z-coordinate {m}
+    21.9884710655839,        !- Vertex 4 X-coordinate {m}
+    3.61703301654305,        !- Vertex 4 Y-coordinate {m}
+    4.72;                    !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 6,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    18.6284710655839,        !- Vertex 1 X-coordinate {m}
+    2.37667133434807,        !- Vertex 1 Y-coordinate {m}
+    3.90341289084577,        !- Vertex 1 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 2 X-coordinate {m}
+    2.37667133434807,        !- Vertex 2 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 2 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 3 X-coordinate {m}
+    2.37667133434807,        !- Vertex 3 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 3 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 4 X-coordinate {m}
+    2.37667133434807,        !- Vertex 4 Y-coordinate {m}
+    3.90341289084577;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 7,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    19.1284710655839,        !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    4.00379559078073,        !- Vertex 1 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 2 X-coordinate {m}
+    2.37667133434807,        !- Vertex 2 Y-coordinate {m}
+    3.90341289084577,        !- Vertex 2 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 3 X-coordinate {m}
+    2.37667133434807,        !- Vertex 3 Y-coordinate {m}
+    3.30341289084577,        !- Vertex 3 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    3.90379559078073;        !- Vertex 4 Z-coordinate {m}
+
+Shading:Building:Detailed,
+    Shading Surface 8,       !- Name
+    ,                        !- Transmittance Schedule Name
+    ,                        !- Number of Vertices
+    19.1284710655839,        !- Vertex 1 X-coordinate {m}
+    6.13906958727383,        !- Vertex 1 Y-coordinate {m}
+    4.00379559078073,        !- Vertex 1 Z-coordinate {m}
+    19.1284710655839,        !- Vertex 2 X-coordinate {m}
+    6.13906958727383,        !- Vertex 2 Y-coordinate {m}
+    3.90379559078073,        !- Vertex 2 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 3 X-coordinate {m}
+    6.13906958727383,        !- Vertex 3 Y-coordinate {m}
+    3.90379559078075,        !- Vertex 3 Z-coordinate {m}
+    18.6284710655839,        !- Vertex 4 X-coordinate {m}
+    6.13906958727383,        !- Vertex 4 Y-coordinate {m}
+    4.00379559078075;        !- Vertex 4 Z-coordinate {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: ELECTRICEQUIPMENT ===========
+
+ElectricEquipment,
+    Mac,                     !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Mac,                     !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    166,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    0.1,                     !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    HP,                      !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    HP,                      !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    325,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    0.1,                     !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    MonitorDell,             !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    MonitorDell,             !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    166,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    0.35,                    !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Fuente,                  !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Fuente,                  !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    294,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Agilent,                 !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Agilent,                 !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    25,                      !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Regulador,               !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Regulador,               !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    5,                       !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+ElectricEquipment,
+    Telefono,                !- Name
+    Cubiculo,                !- Zone or ZoneList Name
+    Telefono,                !- Schedule Name
+    EquipmentLevel,          !- Design Level Calculation Method
+    1.5,                     !- Design Level {W}
+    ,                        !- Watts per Zone Floor Area {W/m2}
+    ,                        !- Watts per Person {W/person}
+    ,                        !- Fraction Latent
+    ,                        !- Fraction Radiant
+    ,                        !- Fraction Lost
+    General;                 !- End-Use Subcategory
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:SIMULATIONCONTROL ===========
+
+AirflowNetwork:SimulationControl,
+    SC ,                     !- Name
+    MultizoneWithoutDistribution,  !- AirflowNetwork Control
+    SurfaceAverageCalculation,  !- Wind Pressure Coefficient Type
+    ,                        !- Height Selection for Local Wind Pressure Calculation
+    LowRise,                 !- Building Type
+    500,                     !- Maximum Number of Iterations {dimensionless}
+    ZeroNodePressures,       !- Initialization Type
+    0.0001,                  !- Relative Airflow Convergence Tolerance {dimensionless}
+    0.000001,                !- Absolute Airflow Convergence Tolerance {kg/s}
+    -.5,                     !- Convergence Acceleration Limit {dimensionless}
+    ,                        !- Azimuth Angle of Long Axis of Building {deg}
+    1,                       !- Ratio of Building Width Along Short Axis to Width Along Long Axis
+    No,                      !- Height Dependence of External Node Temperature
+    SkylineLU,               !- Solver
+    No;                      !- Allow Unsupported Zone Equipment
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:ZONE ===========
+
+AirflowNetwork:MultiZone:Zone,
+    Cubiculo,                !- Zone Name
+    NoVent,                  !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    Standard,                !- Single Sided Wind Pressure Coefficient Algorithm
+    10;                      !- Facade Width {m}
+
+AirflowNetwork:MultiZone:Zone,
+    CubiculoTecho,           !- Zone Name
+    NoVent,                  !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    Standard,                !- Single Sided Wind Pressure Coefficient Algorithm
+    10;                      !- Facade Width {m}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:SURFACE ===========
+
+AirflowNetwork:MultiZone:Surface,
+    VCNI,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCNS,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    PuertaJorge,             !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCSI,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VCSS,                    !- Surface Name
+    InfiltracionCubiculo,    !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VNT,                     !- Surface Name
+    InfiltracionTecho,       !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+AirflowNetwork:MultiZone:Surface,
+    VST,                     !- Surface Name
+    InfiltracionTecho,       !- Leakage Component Name
+    ,                        !- External Node Name
+    1,                       !- Window/Door Opening Factor, or Crack Factor {dimensionless}
+    ZoneLevel,               !- Ventilation Control Mode
+    ,                        !- Ventilation Control Zone Temperature Setpoint Schedule Name
+    ,                        !- Minimum Venting Open Factor {dimensionless}
+    ,                        !- Indoor and Outdoor Temperature Difference Lower Limit For Maximum Venting Open Factor {deltaC}
+    100,                     !- Indoor and Outdoor Temperature Difference Upper Limit for Minimum Venting Open Factor {deltaC}
+    ,                        !- Indoor and Outdoor Enthalpy Difference Lower Limit For Maximum Venting Open Factor {deltaJ/kg}
+    300000,                  !- Indoor and Outdoor Enthalpy Difference Upper Limit for Minimum Venting Open Factor {deltaJ/kg}
+    ,                        !- Venting Availability Schedule Name
+    ,                        !- Occupant Ventilation Control Name
+    PolygonHeight,           !- Equivalent Rectangle Method
+    1;                       !- Equivalent Rectangle Aspect Ratio {dimensionless}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:REFERENCECRACKCONDITIONS ===========
+
+AirflowNetwork:MultiZone:ReferenceCrackConditions,
+    Infiltracion ,           !- Name
+    20,                      !- Reference Temperature {C}
+    86864,                   !- Reference Barometric Pressure {Pa}
+    0;                       !- Reference Humidity Ratio {kgWater/kgDryAir}
+
+
+!-   ===========  ALL OBJECTS IN CLASS: AIRFLOWNETWORK:MULTIZONE:SURFACE:CRACK ===========
+
+AirflowNetwork:MultiZone:Surface:Crack,
+    InfiltracionTecho,       !- Name
+    0.5,                     !- Air Mass Flow Coefficient at Reference Conditions {kg/s}
+    0.65,                    !- Air Mass Flow Exponent {dimensionless}
+    Infiltracion ;           !- Reference Crack Conditions
+
+AirflowNetwork:MultiZone:Surface:Crack,
+    InfiltracionCubiculo,    !- Name
+    0.02,                    !- Air Mass Flow Coefficient at Reference Conditions {kg/s}
+    0.65,                    !- Air Mass Flow Exponent {dimensionless}
+    Infiltracion ;           !- Reference Crack Conditions
+
+
+!-   ===========  ALL OBJECTS IN CLASS: SIZING:PARAMETERS ===========
+
+Sizing:Parameters,
+    1.25,                    !- Heating Sizing Factor
+    1.15;                    !- Cooling Sizing Factor
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTDOORAIR:NODE ===========
+
+OutdoorAir:Node,
+    Model Outdoor Air Node;  !- Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:VARIABLEDICTIONARY ===========
+
+Output:VariableDictionary,
+    IDF,                     !- Key Field
+    Unsorted;                !- Sort Option
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:TABLE:SUMMARYREPORTS ===========
+
+Output:Table:SummaryReports,
+    AllSummary;              !- Report 1 Name
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUTCONTROL:TABLE:STYLE ===========
+
+OutputControl:Table:Style,
+    HTML;                    !- Column Separator
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:VARIABLE ===========
+
+Output:Variable,
+    Cubiculo ,               !- Key Value
+    Zone Mean Air Temperature,  !- Variable Name
+    Timestep;                !- Reporting Frequency
+
+
+!-   ===========  ALL OBJECTS IN CLASS: OUTPUT:SQLITE ===========
+
+Output:SQLite,
+    SimpleAndTabular;        !- Option Type
+


### PR DESCRIPTION
Aquí se encuentran los archivos IDF de los casos base analizados con las distintas métricas. A continuación se presentan las principales diferencias entre los casos.
PF_B1: Caso dónde a todos los equipos eléctricos con un porcentaje del 20% de su consumo en horarios en los cuales no se hace uso de los equipos pero si se encuentran conectados.  Coeficiente para Air Mass Flow Coefficient at Reference Conditions de 0.01 kg/s.
PF_B2: Caso dónde se le asigna un porcentaje específico de consumo a cada equipo eléctrico de acuerdo a un acercamiento más realista de acuerdo al inventario de equipo proporcionado en el repositorio del Dr. Guillermo Barrios. Considerando así que equipos si son más factibles de utilizarse todo el tiempo de ocupación y cuales podrían representar un porcentaje menor por su poco uso. Coeficiente para Air Mass Flow Coefficient at Reference Conditions de 0.01 kg/s.
PF_B3: Al caso base PF_B2 se le implementa la asignación de un coeficiente para Air Mass Flow Coefficient at Reference Conditions de 0.02 kg/s.